### PR TITLE
Use latest format for `index.json`

### DIFF
--- a/providers/github/types/index.json
+++ b/providers/github/types/index.json
@@ -1,1 +1,1 @@
-{"Resources":{"repositories@v1":{"RelativePath":"github\\repositories\\v1\\types.json","Index":27}}, "Functions":{}}
+{"Resources":{"repositories@v1":{"RelativePath":"github/repositories/v1/types.json","Index":27}}, "Functions":{}}

--- a/providers/github/types/index.json
+++ b/providers/github/types/index.json
@@ -1,1 +1,1 @@
-{"Types":{"repositories@v1":{"RelativePath":"github\\repositories\\v1\\types.json","Index":27}}}
+{"Resources":{"repositories@v1":{"RelativePath":"github\\repositories\\v1\\types.json","Index":27}}, "Functions":{}}


### PR DESCRIPTION
This aligns with the format used in https://github.com/Azure/bicep-types-az/blob/main/src/Bicep.Types.Az/Index/TypeIndex.cs for `az` types.